### PR TITLE
Custom Arrow

### DIFF
--- a/WYPopoverController/WYPopoverController.h
+++ b/WYPopoverController/WYPopoverController.h
@@ -48,11 +48,18 @@ typedef NS_OPTIONS(NSUInteger, WYPopoverArrowDirection) {
   WYPopoverArrowDirectionUnknown = NSUIntegerMax
 };
 
+typedef NS_OPTIONS(NSUInteger, WYPopoverArrowStyle) {
+  WYPopoverArrowStyleLeftHalf = 1UL << 0,
+  WYPopoverArrowStyleRightHalf = 1UL << 0,
+  WYPopoverArrowStyleFull = WYPopoverArrowStyleLeftHalf | WYPopoverArrowStyleRightHalf,
+};
+
 typedef NS_OPTIONS(NSUInteger, WYPopoverAnimationOptions) {
   WYPopoverAnimationOptionFade = 1UL << 0,            // default
   WYPopoverAnimationOptionScale = 1UL << 1,
   WYPopoverAnimationOptionFadeWithScale = WYPopoverAnimationOptionFade | WYPopoverAnimationOptionScale
 };
+
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -74,7 +81,7 @@ typedef NS_OPTIONS(NSUInteger, WYPopoverAnimationOptions) {
 @property (nonatomic, assign) NSUInteger borderWidth                        UI_APPEARANCE_SELECTOR;
 @property (nonatomic, assign) NSUInteger arrowBase                          UI_APPEARANCE_SELECTOR;
 @property (nonatomic, assign) NSUInteger arrowHeight                        UI_APPEARANCE_SELECTOR;
-@property (nonatomic, assign) BOOL useSpacyArrow                            UI_APPEARANCE_SELECTOR;
+@property (nonatomic, assign) WYPopoverArrowStyle arrowStyle                UI_APPEARANCE_SELECTOR;
 
 @property (nonatomic, strong) UIColor *outerShadowColor                     UI_APPEARANCE_SELECTOR;
 @property (nonatomic, strong) UIColor *outerStrokeColor                     UI_APPEARANCE_SELECTOR;
@@ -252,7 +259,7 @@ typedef NS_OPTIONS(NSUInteger, WYPopoverAnimationOptions) {
 @property (nonatomic, assign) NSUInteger  borderWidth;
 @property (nonatomic, assign) NSUInteger  arrowBase;
 @property (nonatomic, assign) NSUInteger  arrowHeight;
-@property (nonatomic, assign) BOOL useSpacyArrow;
+@property (nonatomic, assign) WYPopoverArrowStyle arrowStyle;
 
 @property (nonatomic, strong) UIColor *outerShadowColor;
 @property (nonatomic, strong) UIColor *outerStrokeColor;

--- a/WYPopoverController/WYPopoverController.h
+++ b/WYPopoverController/WYPopoverController.h
@@ -49,8 +49,9 @@ typedef NS_OPTIONS(NSUInteger, WYPopoverArrowDirection) {
 };
 
 typedef NS_OPTIONS(NSUInteger, WYPopoverArrowStyle) {
+  WYPopoverArrowStyleNone = 0,
   WYPopoverArrowStyleLeftHalf = 1UL << 0,
-  WYPopoverArrowStyleRightHalf = 1UL << 0,
+  WYPopoverArrowStyleRightHalf = 1UL << 1,
   WYPopoverArrowStyleFull = WYPopoverArrowStyleLeftHalf | WYPopoverArrowStyleRightHalf,
 };
 

--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -432,7 +432,7 @@ static char const * const UINavigationControllerEmbedInPopoverTagKey = "UINaviga
   result.borderWidth = 6;
   result.arrowBase = 42;
   result.arrowHeight = 18;
-  result.useSpacyArrow = NO;
+  result.arrowStyle = WYPopoverArrowStyleFull;
   result.outerShadowColor = [UIColor colorWithWhite:0 alpha:0.75];
   result.outerShadowBlurRadius = 8;
   result.outerShadowOffset = CGSizeMake(0, 2);
@@ -467,7 +467,7 @@ static char const * const UINavigationControllerEmbedInPopoverTagKey = "UINaviga
   result.borderWidth = 0;
   result.arrowBase = 25;
   result.arrowHeight = 13;
-  result.useSpacyArrow = NO;
+  result.arrowStyle = WYPopoverArrowStyleFull;
   result.outerShadowColor = [UIColor clearColor];
   result.outerShadowBlurRadius = 0;
   result.outerShadowOffset = CGSizeZero;
@@ -1055,9 +1055,9 @@ static float edgeSizeFromCornerRadius(float cornerRadius) {
     if (_arrowDirection == WYPopoverArrowDirectionUp) {
       arrowTipPoint = CGPointMake(CGRectGetMidX(outerRect) + _arrowOffset,
                                   CGRectGetMinY(outerRect) - _arrowHeight);
-      arrowBasePointA = CGPointMake(arrowTipPoint.x - _arrowBase / 2,
+      arrowBasePointA = CGPointMake(arrowTipPoint.x - ((_arrowStyle & WYPopoverArrowStyleLeftHalf) ? 0 : (_arrowBase / 2)),
                                     arrowTipPoint.y + _arrowHeight);
-      arrowBasePointB = CGPointMake(arrowTipPoint.x + (_useSpacyArrow ? 0 : (_arrowBase / 2)),
+      arrowBasePointB = CGPointMake(arrowTipPoint.x + ((_arrowStyle & WYPopoverArrowStyleRightHalf) ? 0 : (_arrowBase / 2)),
                                     arrowTipPoint.y + _arrowHeight);
 
       CGPathMoveToPoint(outerPathRef, NULL, arrowBasePointA.x, arrowBasePointA.y);
@@ -1544,7 +1544,7 @@ static WYPopoverTheme *defaultTheme_ = nil;
     _theme.borderWidth = appearance.borderWidth;
     _theme.arrowBase = appearance.arrowBase;
     _theme.arrowHeight = appearance.arrowHeight;
-    _theme.useSpacyArrow = appearance.useSpacyArrow;
+    _theme.arrowStyle = appearance.arrowStyle;
     _theme.outerShadowColor = appearance.outerShadowColor;
     _theme.outerShadowBlurRadius = appearance.outerShadowBlurRadius;
     _theme.outerShadowOffset = appearance.outerShadowOffset;
@@ -1625,7 +1625,7 @@ static WYPopoverTheme *defaultTheme_ = nil;
     _backgroundView.borderWidth = _theme.borderWidth;
     _backgroundView.arrowBase = _theme.arrowBase;
     _backgroundView.arrowHeight = _theme.arrowHeight;
-    _backgroundView.useSpacyArrow = _theme.useSpacyArrow;
+    _backgroundView.arrowStyle = _backgroundView.arrowStyle;
     _backgroundView.outerShadowColor = _theme.outerShadowColor;
     _backgroundView.outerShadowBlurRadius = _theme.outerShadowBlurRadius;
     _backgroundView.outerShadowOffset = _theme.outerShadowOffset;

--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -1056,9 +1056,9 @@ static float edgeSizeFromCornerRadius(float cornerRadius) {
       arrowTipPoint = CGPointMake(CGRectGetMidX(outerRect) + _arrowOffset,
                                   CGRectGetMinY(outerRect) - _arrowHeight);
         
-        arrowBasePointA = CGPointMake(arrowTipPoint.x - ((_arrowStyle & WYPopoverArrowStyleLeftHalf) ? (_arrowBase / 2) : 0),
+      arrowBasePointA = CGPointMake(arrowTipPoint.x - ((_arrowStyle & WYPopoverArrowStyleLeftHalf) ? (_arrowBase / 2) : 0),
                                     arrowTipPoint.y + _arrowHeight);
-        arrowBasePointB = CGPointMake(arrowTipPoint.x + ((_arrowStyle & WYPopoverArrowStyleRightHalf) ? (_arrowBase / 2) : 0),
+      arrowBasePointB = CGPointMake(arrowTipPoint.x + ((_arrowStyle & WYPopoverArrowStyleRightHalf) ? (_arrowBase / 2) : 0),
                                     arrowTipPoint.y + _arrowHeight);
 
       CGPathMoveToPoint(outerPathRef, NULL, arrowBasePointA.x, arrowBasePointA.y);

--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -529,7 +529,7 @@ static char const * const UINavigationControllerEmbedInPopoverTagKey = "UINaviga
 }
 
 - (NSArray *)observableKeypaths {
-  return [NSArray arrayWithObjects:@"tintColor", @"outerStrokeColor", @"innerStrokeColor", @"fillTopColor", @"fillBottomColor", @"glossShadowColor", @"glossShadowOffset", @"glossShadowBlurRadius", @"borderWidth", @"arrowBase", @"arrowHeight", @"useSpacyArrow", @"outerShadowColor", @"outerShadowBlurRadius", @"outerShadowOffset", @"outerCornerRadius", @"innerShadowColor", @"innerShadowBlurRadius", @"innerShadowOffset", @"innerCornerRadius", @"viewContentInsets", @"overlayColor", nil];
+  return [NSArray arrayWithObjects:@"tintColor", @"outerStrokeColor", @"innerStrokeColor", @"fillTopColor", @"fillBottomColor", @"glossShadowColor", @"glossShadowOffset", @"glossShadowBlurRadius", @"borderWidth", @"arrowBase", @"arrowHeight", @"arrowStyle", @"outerShadowColor", @"outerShadowBlurRadius", @"outerShadowOffset", @"outerCornerRadius", @"innerShadowColor", @"innerShadowBlurRadius", @"innerShadowOffset", @"innerCornerRadius", @"viewContentInsets", @"overlayColor", nil];
 }
 
 @end
@@ -1055,9 +1055,10 @@ static float edgeSizeFromCornerRadius(float cornerRadius) {
     if (_arrowDirection == WYPopoverArrowDirectionUp) {
       arrowTipPoint = CGPointMake(CGRectGetMidX(outerRect) + _arrowOffset,
                                   CGRectGetMinY(outerRect) - _arrowHeight);
-      arrowBasePointA = CGPointMake(arrowTipPoint.x - ((_arrowStyle & WYPopoverArrowStyleLeftHalf) ? 0 : (_arrowBase / 2)),
+        
+        arrowBasePointA = CGPointMake(arrowTipPoint.x - ((_arrowStyle & WYPopoverArrowStyleLeftHalf) ? (_arrowBase / 2) : 0),
                                     arrowTipPoint.y + _arrowHeight);
-      arrowBasePointB = CGPointMake(arrowTipPoint.x + ((_arrowStyle & WYPopoverArrowStyleRightHalf) ? 0 : (_arrowBase / 2)),
+        arrowBasePointB = CGPointMake(arrowTipPoint.x + ((_arrowStyle & WYPopoverArrowStyleRightHalf) ? (_arrowBase / 2) : 0),
                                     arrowTipPoint.y + _arrowHeight);
 
       CGPathMoveToPoint(outerPathRef, NULL, arrowBasePointA.x, arrowBasePointA.y);
@@ -1492,6 +1493,7 @@ static WYPopoverTheme *defaultTheme_ = nil;
     appearance.borderWidth = aTheme.borderWidth;
     appearance.arrowBase = aTheme.arrowBase;
     appearance.arrowHeight = aTheme.arrowHeight;
+    appearance.arrowStyle = aTheme.arrowStyle;
     appearance.outerShadowColor = aTheme.outerShadowColor;
     appearance.outerShadowBlurRadius = aTheme.outerShadowBlurRadius;
     appearance.outerShadowOffset = aTheme.outerShadowOffset;
@@ -1625,7 +1627,7 @@ static WYPopoverTheme *defaultTheme_ = nil;
     _backgroundView.borderWidth = _theme.borderWidth;
     _backgroundView.arrowBase = _theme.arrowBase;
     _backgroundView.arrowHeight = _theme.arrowHeight;
-    _backgroundView.arrowStyle = _backgroundView.arrowStyle;
+    _backgroundView.arrowStyle = _theme.arrowStyle;
     _backgroundView.outerShadowColor = _theme.outerShadowColor;
     _backgroundView.outerShadowBlurRadius = _theme.outerShadowBlurRadius;
     _backgroundView.outerShadowOffset = _theme.outerShadowOffset;


### PR DESCRIPTION
Instead of `useSpacyArrow`, an `arrowStyle` has been introduced which is an NS_OPTION type. 

It has the Options `WYPopoverArrowStyleNone`, `WYPopoverArrowStyleLeftHalf`, `WYPopoverArrowStyleRightHalf` and `WYPopoverArrowStyleFull`.

Setting `arrowStyle = WYPopoverArrowStyleLeftHalf` is equivalent to `useSpacyArrow = YES`. 